### PR TITLE
Fix scroll bar issue on Windows

### DIFF
--- a/src/style/style.css
+++ b/src/style/style.css
@@ -44,7 +44,7 @@ body {
 .prism-code {
   background: none !important;
   padding: 0 !important;
-  overflow: scroll;
+  overflow: hidden auto;
   max-width: 40vw;
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8299278/46995895-dff29b00-d144-11e8-8313-53205f3d2403.png)

On Windows scroll bar is always show from my PR I've change overflow-x to hidden and overflow-y to auto result will be like screenshot below

![image](https://user-images.githubusercontent.com/8299278/46995971-221bdc80-d145-11e8-8739-99bd6f41c165.png)
