### PR TITLE
Add React import to code preview

### DIFF
--- a/src/utils/template.js
+++ b/src/utils/template.js
@@ -27,6 +27,13 @@ ${!importDeclaration ? 'render(<MyLoader />)' : ''}`
 
 export const ReactImport = () => (
   <pre className="prism-code">
+    <span className="token keyword">import</span> React{' '}
+    <span className="token keyword">from </span>
+    <span className="token string">"react"</span>
+    <br />
+    <br />
+  </pre>
+  <pre className="prism-code">
     <span className="token keyword">import</span> ContentLoader{' '}
     <span className="token keyword">from </span>
     <span className="token string">"react-content-loader"</span>


### PR DESCRIPTION
This makes copy and pasting the code preview easier; react should always be imported when there is JSX returned