### PR TITLE
Correct view source URL for 4 gallery items with unnecessary filename extension

### DIFF
--- a/src/Gallery/insertYourLoaderHere/ArticleLoader.js
+++ b/src/Gallery/insertYourLoaderHere/ArticleLoader.js
@@ -48,7 +48,7 @@ ArticleLoader.metadata = {
   name: 'Sridhar Easwaran',
   github: 'sridhareaswaran',
   description: 'Article or News',
-  filename: 'ArticleLoader.js',
+  filename: 'ArticleLoader',
 }
 
 export default ArticleLoader

--- a/src/Gallery/insertYourLoaderHere/DashboardLoader.js
+++ b/src/Gallery/insertYourLoaderHere/DashboardLoader.js
@@ -78,7 +78,7 @@ DashboardLoader.metadata = {
   name: 'Sridhar Easwaran',
   github: 'sridhareaswaran',
   description: 'Dashboard pages',
-  filename: 'DashboardLoader.js',
+  filename: 'DashboardLoader',
 }
 
 export default DashboardLoader

--- a/src/Gallery/insertYourLoaderHere/TableLoader.js
+++ b/src/Gallery/insertYourLoaderHere/TableLoader.js
@@ -68,7 +68,7 @@ TableLoader.metadata = {
   name: 'Sridhar Easwaran',
   github: 'sridhareaswaran',
   description: 'Loader for Tables',
-  filename: 'TableLoader.js',
+  filename: 'TableLoader',
 }
 
 export default TableLoader

--- a/src/Gallery/insertYourLoaderHere/XYChart.js
+++ b/src/Gallery/insertYourLoaderHere/XYChart.js
@@ -23,7 +23,7 @@ XYChart.metadata = {
   name: 'XYChart', // My name
   github: 'ankursehdev', // Github username
   description: 'XY Chart Loading', // Little tagline
-  filename: 'XYChart.js', // filename of your loader
+  filename: 'XYChart', // filename of your loader
 }
 
 export default XYChart


### PR DESCRIPTION
Hello danilo,

If you go to your RCL gallery on:
http://danilowoz.com/create-content-loader/#gallery

You may notice that 4 of the gallery items (ArticleLoader and the other 3 listed in this PR) lead to an 404 github page due to an unnecessary `.js` in their filename value.

This PR should resolve it.

Thank you for your great work. Big fan
