### PR TITLE
feat(vue): use viewBox instead of width/height

### DIFF
--- a/src/utils/template.js
+++ b/src/utils/template.js
@@ -162,8 +162,7 @@ const vue = ({ data = {} }) => {
 
 <template>
   <content-loader
-    :width="${data.width}"
-    :height="${data.height}"
+    viewBox="0 0 ${data.width} ${data.height}"
     :speed="${data.speed}"
     primaryColor="${data.backgroundColor}"
     secondaryColor="${data.foregroundColor}"


### PR DESCRIPTION
To better align with other frameworks behavior and allow the element to be responsive by default.