### PR TITLE
fix: broken URLs from template gallery

### DIFF
--- a/src/Gallery/index.jsx
+++ b/src/Gallery/index.jsx
@@ -38,7 +38,7 @@ const renderItem = (item, index) => {
 
         <a
           className="source"
-          href={`https://github.com/danilowoz/create-content-loader/blob/master/src/Gallery/insertYourLoaderHere/${filename}.js`}
+          href={`https://github.com/danilowoz/create-content-loader/blob/master/src/Gallery/insertYourLoaderHere/${filename}.jsx`}
           target="_blank"
           rel="noopener noreferrer"
           onClick={() => {


### PR DESCRIPTION
I was wondering why the gallery templates on [https://skeletonreact.com](https://skeletonreact.com) weren't redirecting to the correct URL, looks like some time ago, all files on `/src/Gallery/insertYourLoaderHere/` were renamed to `.jsx` extension, and now the links on the gallery are "broken" when we click on view source, returning an 404 page. The URLs lead to Github, and the URL path includes the exact file name of template.

Nothing too much, we can just alter the extension on the URL to fix the problem.